### PR TITLE
Add helper scripts for environment setup and configurable transcoder runs

### DIFF
--- a/scripts/run_transcoder.py
+++ b/scripts/run_transcoder.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Run a configurable transcoder experiment.
+
+This script generalizes the behaviour of ``tests/test_transcoder.py`` so that
+users can try different Gym environments and stable-baselines3 models without
+modifying source code.  It collects activations, trains a transcoder for the
+specified layer and reports the strongest correlations.
+"""
+
+import argparse
+from importlib import import_module
+from pathlib import Path
+
+import gymnasium as gym
+from interlatent.api import LatentDB
+from interlatent.collector import Collector
+from interlatent.metrics import LambdaMetric
+from interlatent.train.pipeline import TranscoderPipeline
+
+
+def parse_metric(spec: str):
+    """Parse a ``name:expr`` specification into a LambdaMetric.
+
+    The expression is evaluated with ``obs`` in scope.  Example::
+
+        pole_angle:obs[2]
+    """
+    name, expr = spec.split(":", 1)
+
+    def fn(obs, **kwargs):
+        return eval(expr, {"obs": obs})
+
+    return LambdaMetric(name, fn)
+
+
+def load_policy(algo: str, path: str):
+    """Dynamically load a Stable-Baselines3 policy from ``path``."""
+    sb3 = import_module("stable_baselines3")
+    cls = getattr(sb3, algo)
+    return cls.load(path).policy
+
+
+def main():
+    p = argparse.ArgumentParser(description="Run transcoder experiment")
+    p.add_argument("--env-id", required=True, help="Gym environment id")
+    p.add_argument("--algo", default="PPO", help="SB3 algorithm class name")
+    p.add_argument("--model-path", required=True, help="Path to trained SB3 model")
+    p.add_argument("--steps", type=int, default=200, help="Steps to collect")
+    p.add_argument("--epochs", type=int, default=3, help="Transcoder training epochs")
+    p.add_argument("--k", type=int, default=4, help="Bottleneck dimension")
+    p.add_argument("--layer", default="mlp_extractor.policy_net.0",
+                   help="Model layer to hook")
+    p.add_argument("--metric", action="append",
+                   help="Optional metric as name:expr evaluated on obs")
+    p.add_argument("--db-path", default="latents.db",
+                   help="Where to store the SQLite database")
+    args = p.parse_args()
+
+    env = gym.make(args.env_id)
+    policy = load_policy(args.algo, args.model_path)
+
+    db = LatentDB(f"sqlite:///{Path(args.db_path).resolve()}")
+
+    metrics = [parse_metric(m) for m in args.metric] if args.metric else []
+    collector = Collector(db, hook_layers=[args.layer], metric_fns=metrics)
+    collector.run(policy, env, steps=args.steps)
+
+    pipe = TranscoderPipeline(db, args.layer, k=args.k, epochs=args.epochs)
+    pipe.run()
+
+    if metrics:
+        db.compute_stats(min_count=1)
+        latent_layer = f"latent:{args.layer}"
+        for sb in db.iter_statblocks(layer=latent_layer):
+            print(sb.top_correlations)
+
+    db.close()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/run_transcoder.sh
+++ b/scripts/run_transcoder.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Convenience wrapper around run_transcoder.py
+# Usage example:
+#   ./scripts/run_transcoder.sh --env-id CartPole-v1 --algo PPO \
+#       --model-path pretrained/ppo-CartPole-v1.zip --metric pole_angle:obs[2]
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python "$SCRIPT_DIR/run_transcoder.py" "$@"
+

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine location of environment.yaml relative to this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/../environment.yaml"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "environment.yaml not found at $ENV_FILE" >&2
+  exit 1
+fi
+
+# Default environment name from file or first argument
+DEFAULT_NAME=$(grep '^name:' "$ENV_FILE" | awk '{print $2}')
+ENV_NAME=${1:-$DEFAULT_NAME}
+
+# Prefer mamba if available for faster installs
+if command -v mamba >/dev/null 2>&1; then
+  CONDA_CMD="mamba"
+elif command -v conda >/dev/null 2>&1; then
+  CONDA_CMD="conda"
+else
+  echo "Neither conda nor mamba is installed. Please install one first." >&2
+  exit 1
+fi
+
+if $CONDA_CMD env list | grep -q "^$ENV_NAME\s"; then
+  echo "Updating existing environment '$ENV_NAME' using $CONDA_CMD"
+  $CONDA_CMD env update -f "$ENV_FILE" -n "$ENV_NAME"
+else
+  echo "Creating environment '$ENV_NAME' using $CONDA_CMD"
+  $CONDA_CMD env create -f "$ENV_FILE" -n "$ENV_NAME"
+fi
+
+echo "Environment ready. Activate with: conda activate $ENV_NAME"
+


### PR DESCRIPTION
## Summary
- add `setup_env.sh` to build or update conda environment from `environment.yaml`
- add `run_transcoder.py` to run configurable transcoder experiments with SB3 models and Gym envs
- add `run_transcoder.sh` convenience wrapper for the Python script

## Testing
- `pytest tests/test_end_to_end.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68c5480f838c832e98de59ced2593a74