### PR TITLE
Configure setuptools build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "interlatent"
 version = "0.0.0"
@@ -9,3 +13,7 @@ dev = [
   "gymnasium",
   "pytest",
 ]
+
+[tool.setuptools.packages.find]
+include = ["interlatent"]
+exclude = ["tests", "scripts", "runs", "keys", "artifacts", "pretrained"]


### PR DESCRIPTION
## Summary
- add build system config using setuptools build backend
- limit package discovery to the `interlatent` package

## Testing
- `pip install -e . --no-build-isolation` *(fails: invalid command 'bdist_wheel')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'interlatent'; ModuleNotFoundError: No module named 'torch'; ModuleNotFoundError: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_68c54f016444832e8974ba0001aff288